### PR TITLE
Remember Window Size & Enable Mic Access

### DIFF
--- a/DiscordSafari/Base.lproj/Main.storyboard
+++ b/DiscordSafari/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
-        <plugIn identifier="com.apple.WebKit2IBPlugin" version="17506"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19455"/>
+        <plugIn identifier="com.apple.WebKit2IBPlugin" version="19455"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -365,7 +366,7 @@
         <scene sceneID="R2V-B0-nI4">
             <objects>
                 <windowController id="B8D-0N-5wS" sceneMemberID="viewController">
-                    <window key="window" title="DiscordSafari" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" titleVisibility="hidden" id="IQv-IB-iLA">
+                    <window key="window" title="DiscordSafari" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="DiscordSafariFrameSave" animationBehavior="default" titleVisibility="hidden" id="IQv-IB-iLA">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
                         <rect key="contentRect" x="196" y="240" width="480" height="270"/>

--- a/DiscordSafari/DiscordSafari.entitlements
+++ b/DiscordSafari/DiscordSafari.entitlements
@@ -4,6 +4,8 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
 	<key>com.apple.security.network.client</key>

--- a/DiscordSafari/Info.plist
+++ b/DiscordSafari/Info.plist
@@ -26,6 +26,8 @@
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSMainStoryboardFile</key>
 	<string>Main</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Discord needs mic access for voice calls!</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 </dict>

--- a/DiscordSafari/ViewController.swift
+++ b/DiscordSafari/ViewController.swift
@@ -7,6 +7,7 @@
 
 import Cocoa
 import WebKit
+import AVFoundation
 
 class ViewController: NSViewController, WKUIDelegate, WKNavigationDelegate {
     @IBOutlet weak var webview: WKWebView!
@@ -15,6 +16,10 @@ class ViewController: NSViewController, WKUIDelegate, WKNavigationDelegate {
         super.viewDidLoad()
         self.webview.uiDelegate = self
         self.webview.navigationDelegate = self
+        self.webview.customUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15"
+        
+        AVCaptureDevice.requestAccess(for: .audio, completionHandler: {_ in})
+        
         let myURL = URL(string: "https://discord.com/app")
         let myRequest = URLRequest(url: myURL!)
         self.webview.load(myRequest)


### PR DESCRIPTION
Remembers window size by setting autosave to address #1 

Also requests mic access and sets the user-agent to macOS safari to allow for voice calls through Discord. 

Could potentially generate user-agent string programmatically, but I figured this would work fine for now, if it breaks its easy enough to update. 